### PR TITLE
feat: NotificationService + forgot/reset password + admin reset forçado

### DIFF
--- a/models.py
+++ b/models.py
@@ -52,3 +52,15 @@ class BloqueioHorario(Base):
     horario = Column(String, nullable=False)
     motivo = Column(String, nullable=True)
     criado_em = Column(DateTime, default=datetime.utcnow)
+
+
+# Issue #3 / #5 — Token de reset de senha self-service
+class PasswordResetToken(Base):
+    __tablename__ = "password_reset_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    cliente_id = Column(Integer, ForeignKey("clientes.id"), nullable=False)
+    token = Column(String, unique=True, nullable=False)
+    usado = Column(Boolean, default=False)
+    expira_em = Column(DateTime, nullable=False)
+    criado_em = Column(DateTime, default=datetime.utcnow)

--- a/notifications.py
+++ b/notifications.py
@@ -1,0 +1,65 @@
+# notifications.py — Issue #7: NotificationService + stub
+# Todas as notificações passam por aqui. Por enquanto usa console.log (print).
+# Para integrar Mailgun/SendGrid real, substitua os métodos (_send_email) — Issue #8.
+
+class NotificationService:
+    """Serviço central de notificações. Stub via print."""
+
+    def _send_email(self, to: str, subject: str, body: str):
+        """Stub: imprime no console. Substituir por API real na issue #8."""
+        print(f"[EMAIL] Para: {to} | Assunto: {subject}")
+        print(f"  {body}")
+
+    def send_welcome(self, email: str, nome: str):
+        self._send_email(
+            to=email,
+            subject="Bem-vindo à Barbearia! 💈",
+            body=f"Olá {nome}, seu cadastro foi realizado com sucesso!"
+        )
+
+    def send_password_reset_requested(self, email: str, nome: str, token: str):
+        link = f"https://barber-booking.app/reset-password?token={token}"
+        self._send_email(
+            to=email,
+            subject="Redefinição de senha solicitada",
+            body=(
+                f"Olá {nome},\n"
+                f"Clique no link abaixo para redefinir sua senha (válido por 1h):\n"
+                f"{link}\n\n"
+                "Se não foi você, ignore este e-mail."
+            )
+        )
+
+    def send_password_reset_done(self, email: str, nome: str):
+        self._send_email(
+            to=email,
+            subject="Sua senha foi alterada",
+            body=f"Olá {nome}, sua senha foi redefinida com sucesso. Se não foi você, entre em contato."
+        )
+
+    def send_forced_reset_by_admin(self, email: str, nome: str):
+        self._send_email(
+            to=email,
+            subject="Sua senha foi redefinida pelo administrador",
+            body=(
+                f"Olá {nome},\n"
+                "Sua senha foi redefinida pelo administrador. "
+                "Por favor, crie uma nova senha no próximo acesso."
+            )
+        )
+
+    def send_booking_cancelled_by_barber(self, email: str, nome: str, data_hora: str, motivo: str):
+        self._send_email(
+            to=email,
+            subject="Seu agendamento foi cancelado",
+            body=(
+                f"Olá {nome},\n"
+                f"Seu agendamento em {data_hora} foi cancelado pelo barbeiro.\n"
+                f"Motivo: {motivo}\n"
+                "Entre em contato para reagendar."
+            )
+        )
+
+
+# Instância global — importe de qualquer lugar
+notification_service = NotificationService()

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from database import get_db
 from models import Agendamento, Cliente, Endereco, BloqueioHorario
-from auth import require_admin
+from auth import require_admin, hash_senha
+from notifications import notification_service
 from datetime import date, datetime
 from typing import List, Optional
 from pydantic import BaseModel
@@ -79,9 +80,18 @@ def cancelar_pelo_barbeiro(
     ag = db.query(Agendamento).filter(Agendamento.id == agendamento_id).first()
     if not ag:
         raise HTTPException(status_code=404, detail="Agendamento não encontrado.")
+    cliente = db.query(Cliente).filter(Cliente.id == ag.cliente_id).first()
     ag.status = "cancelado_barbeiro"
     ag.motivo_cancelamento = body.motivo
+    ag.cancelado_por = "barbeiro"
     db.commit()
+    if cliente:
+        notification_service.send_booking_cancelled_by_barber(
+            email=cliente.email,
+            nome=cliente.nome,
+            data_hora=ag.data_hora.strftime("%d/%m/%Y às %H:%M"),
+            motivo=body.motivo
+        )
     return {"message": "Agendamento cancelado.", "motivo": body.motivo}
 
 
@@ -91,7 +101,40 @@ def listar_clientes(
     admin: Cliente = Depends(require_admin)
 ):
     clientes = db.query(Cliente).filter(Cliente.role == "cliente").all()
-    return [{"id": c.id, "nome": c.nome, "telefone": c.telefone, "email": c.email, "criado_em": c.criado_em} for c in clientes]
+    return [
+        {
+            "id": c.id,
+            "nome": c.nome,
+            "telefone": c.telefone,
+            "email": c.email,
+            "precisa_redefinir": c.precisa_redefinir,
+            "criado_em": c.criado_em
+        }
+        for c in clientes
+    ]
+
+
+# --- Issue #9: Reset de senha forçado pelo admin ---
+@router.post("/clientes/{cliente_id}/reset-senha")
+def reset_senha_admin(
+    cliente_id: int,
+    db: Session = Depends(get_db),
+    admin: Cliente = Depends(require_admin)
+):
+    """Admin reseta a senha do cliente para 'teste123' e marca precisa_redefinir=True."""
+    cliente = db.query(Cliente).filter(
+        Cliente.id == cliente_id,
+        Cliente.role == "cliente"
+    ).first()
+    if not cliente:
+        raise HTTPException(status_code=404, detail="Cliente não encontrado.")
+    cliente.senha = hash_senha("teste123")
+    cliente.precisa_redefinir = True
+    db.commit()
+    notification_service.send_forced_reset_by_admin(cliente.email, cliente.nome)
+    return {
+        "message": f"Senha de {cliente.nome} redefinida. Cliente deverá trocar no próximo login."
+    }
 
 
 @router.post("/bloqueios")

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -2,9 +2,16 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 from database import get_db
-from models import Cliente
-from schemas import ClienteCreate, ClienteUpdate, ClienteResponse, TokenResponse, RedefinirSenhaRequest
+from models import Cliente, PasswordResetToken
+from schemas import (
+    ClienteCreate, ClienteUpdate, ClienteResponse,
+    TokenResponse, RedefinirSenhaRequest,
+    ForgotPasswordRequest, ResetPasswordRequest
+)
 from auth import hash_senha, verificar_senha, criar_token, get_cliente_atual
+from notifications import notification_service
+import secrets
+from datetime import datetime, timedelta
 
 router = APIRouter()
 
@@ -20,6 +27,7 @@ def register(cliente: ClienteCreate, db: Session = Depends(get_db)):
     db.add(novo)
     db.commit()
     db.refresh(novo)
+    notification_service.send_welcome(novo.email, novo.nome)
     return novo
 
 
@@ -65,10 +73,65 @@ def redefinir_senha(
     db: Session = Depends(get_db),
     cliente_atual: Cliente = Depends(get_cliente_atual)
 ):
+    """Redefinição obrigatória pós reset pelo admin (Issue #9)."""
     if not cliente_atual.precisa_redefinir:
         raise HTTPException(status_code=400, detail="Redefinição de senha não solicitada.")
     cliente_atual.senha = hash_senha(dados.nova_senha)
     cliente_atual.precisa_redefinir = False
     db.commit()
     db.refresh(cliente_atual)
+    notification_service.send_password_reset_done(cliente_atual.email, cliente_atual.nome)
     return cliente_atual
+
+
+# --- Issue #3: POST /auth/forgot-password ---
+@router.post("/forgot-password")
+def forgot_password(body: ForgotPasswordRequest, db: Session = Depends(get_db)):
+    """Gera token de reset válido por 1h. Retorna 200 mesmo se email não existir."""
+    cliente = db.query(Cliente).filter(Cliente.email == body.email).first()
+    if cliente:
+        token_str = secrets.token_urlsafe(32)
+        expira = datetime.utcnow() + timedelta(hours=1)
+        reset_token = PasswordResetToken(
+            cliente_id=cliente.id,
+            token=token_str,
+            expira_em=expira
+        )
+        db.add(reset_token)
+        db.commit()
+        notification_service.send_password_reset_requested(cliente.email, cliente.nome, token_str)
+    # Sempre retorna 200 para não expor se o email existe
+    return {"message": "Se o email estiver cadastrado, você receberá as instruções de reset."}
+
+
+# --- Issue #5: GET /auth/reset-password (valida token) ---
+@router.get("/reset-password")
+def validar_reset_token(token: str, db: Session = Depends(get_db)):
+    """Valida se o token é válido e não expirou (usado pelo front para habilitar o form)."""
+    reset = db.query(PasswordResetToken).filter(
+        PasswordResetToken.token == token,
+        PasswordResetToken.usado == False
+    ).first()
+    if not reset or reset.expira_em < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Token inválido ou expirado.")
+    return {"valid": True}
+
+
+# --- Issue #5: POST /auth/reset-password (aplica nova senha) ---
+@router.post("/reset-password")
+def reset_password(body: ResetPasswordRequest, db: Session = Depends(get_db)):
+    """Valida token, altera senha e marca token como usado."""
+    reset = db.query(PasswordResetToken).filter(
+        PasswordResetToken.token == body.token,
+        PasswordResetToken.usado == False
+    ).first()
+    if not reset or reset.expira_em < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Token inválido ou expirado.")
+    cliente = db.query(Cliente).filter(Cliente.id == reset.cliente_id).first()
+    if not cliente:
+        raise HTTPException(status_code=404, detail="Cliente não encontrado.")
+    cliente.senha = hash_senha(body.nova_senha)
+    reset.usado = True
+    db.commit()
+    notification_service.send_password_reset_done(cliente.email, cliente.nome)
+    return {"message": "Senha redefinida com sucesso. Faça login."}

--- a/schemas.py
+++ b/schemas.py
@@ -40,6 +40,16 @@ class RedefinirSenhaRequest(BaseModel):
     nova_senha: str
 
 
+# --- Forgot / Reset Password (self-service) — Issues #3 #5 ---
+class ForgotPasswordRequest(BaseModel):
+    email: str
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    nova_senha: str
+
+
 # --- Enderecos ---
 class EnderecoCreate(BaseModel):
     apelido: str


### PR DESCRIPTION
## 📋 Descrição

Implementa o fluxo completo de notificações e reset de senha, resolvendo as issues #7, #3, #5 e #9.

## ✅ Issues resolvidas

- Closes #7 — `NotificationService` com stub via `print` (pronto para integrar Mailgun/SendGrid na #8)
- Closes #3 — `POST /auth/forgot-password` — gera token de 1h, salva no DB, chama `NotificationService`, retorna 200 sempre
- Closes #5 — `GET /auth/reset-password` (valida token) + `POST /auth/reset-password` (aplica nova senha, marca token como usado)
- Closes #9 — `POST /admin/clientes/{id}/reset-senha` — admin reseta senha para `teste123`, marca `precisa_redefinir=True`, notifica cliente

## 📁 Arquivos alterados

| Arquivo | O que mudou |
|---|---|
| `notifications.py` | **NOVO** — `NotificationService` com `send_welcome`, `send_password_reset_requested`, `send_password_reset_done`, `send_forced_reset_by_admin`, `send_booking_cancelled_by_barber` |
| `models.py` | **NOVO modelo** `PasswordResetToken` (token, usado, expira_em) |
| `schemas.py` | Adicionado `ForgotPasswordRequest` e `ResetPasswordRequest` |
| `routes/auth.py` | Adicionado `forgot-password`, `GET/POST reset-password`; `register` e `redefinir-senha` agora chamam `NotificationService` |
| `routes/admin.py` | Adicionado `POST /admin/clientes/{id}/reset-senha`; cancelamento pelo barbeiro agora notifica o cliente |

## 🔄 Fluxo implementado

```
[Self-service]
Usuário → POST /auth/forgot-password → token gerado → NotificationService (email com link)
Usuário → GET /auth/reset-password?token=xxx → valida token
Usuário → POST /auth/reset-password → nova senha salva → token marcado como usado

[Admin forçado]
Admin → POST /admin/clientes/{id}/reset-senha → senha = teste123 + precisa_redefinir=True → NotificationService
Cliente → POST /auth/login → retorna precisa_redefinir: true
Cliente → POST /auth/redefinir-senha → nova senha → precisa_redefinir=False
```

## ⚠️ Próximos passos
- Issue #8: substituir `_send_email` stub pelo Mailgun/SendGrid real em `notifications.py`
- Issues #4, #6, #10: telas de frontend correspondentes